### PR TITLE
Make test context reusable

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -18,10 +18,6 @@ import { getApplication } from './application';
 import { Promise } from './-utils';
 import getTestMetadata from './test-metadata';
 import {
-  registerDestructor,
-  associateDestroyableChild,
-} from '@ember/destroyable';
-import {
   getDeprecationsForContext,
   getDeprecationsDuringCallbackForContext,
   DeprecationFailure,
@@ -186,19 +182,6 @@ export function resumeTest(): void {
   }
 
   context.resumeTest();
-}
-
-/**
-  @private
-  @param {Object} context the test context being cleaned up
-*/
-function cleanup(context: BaseContext) {
-  _teardownAJAXHooks();
-
-  // SAFETY: this is intimate API *designed* for us to override.
-  (Ember as any).testing = false;
-
-  unsetContext();
 }
 
 /**
@@ -386,8 +369,6 @@ export default function setupContext<T extends object>(
 
   _backburner.DEBUG = true;
 
-  registerDestructor(context, cleanup);
-
   _prepareOnerror(context);
 
   return Promise.resolve()
@@ -414,8 +395,6 @@ export default function setupContext<T extends object>(
       return buildOwner(getApplication(), getResolver());
     })
     .then((owner) => {
-      associateDestroyableChild(context, owner);
-
       Object.defineProperty(context, 'owner', {
         configurable: true,
         enumerable: true,

--- a/addon-test-support/@ember/test-helpers/teardown-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-context.ts
@@ -1,8 +1,8 @@
-import { TestContext } from './setup-context';
+import Ember from 'ember';
+import { TestContext, unsetContext } from './setup-context';
 import { Promise } from './-utils';
-import settled from './settled';
+import settled, { _teardownAJAXHooks } from './settled';
 import { _cleanupOnerror } from './setup-onerror';
-import { destroy } from '@ember/destroyable';
 
 /**
   Used by test framework addons to tear down the provided context after testing is completed.
@@ -32,7 +32,14 @@ export default function teardownContext(
     .then(() => {
       _cleanupOnerror(context);
 
-      destroy(context);
+      _teardownAJAXHooks();
+
+      // SAFETY: this is intimate API *designed* for us to override.
+      (Ember as any).testing = false;
+
+      context.owner.destroy();
+
+      unsetContext();
     })
     .finally(() => {
       if (waitForSettled) {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.1.1",
-    "ember-destroyable-polyfill": "^2.0.3"
+    "ember-cli-htmlbars": "^6.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.9",
@@ -66,7 +65,6 @@
     "@types/ember__application": "~4.0.5",
     "@types/ember__component": "~4.0.8",
     "@types/ember__debug": "~4.0.1",
-    "@types/ember__destroyable": "~4.0.0",
     "@types/ember__engine": "~4.0.4",
     "@types/ember__object": "~4.0.2",
     "@types/ember__polyfills": "~4.0.0",

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -257,4 +257,17 @@ module('setupApplicationContext', function (hooks) {
       'after click resolved',
     ]);
   });
+
+  test('can reset context during a test', async function (assert) {
+    await visit('/');
+    assert.equal(currentURL(), '/');
+
+    await teardownContext(this);
+    await setupContext(this);
+    await setupApplicationContext(this);
+    assert.equal(currentURL(), null);
+
+    await visit('/');
+    assert.equal(currentURL(), '/');
+  });
 });

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -944,5 +944,19 @@ module('setupContext', function (hooks) {
         }
       }
     });
+
+    test('can reset context during a test', async function (assert) {
+      assert.expect(1);
+
+      let context = await setupContext({});
+      try {
+        await teardownContext(context);
+        context = await setupContext(context);
+      } finally {
+        await teardownContext(context);
+      }
+
+      assert.ok(true, 'No error calling setupContext after teardownContext');
+    });
   });
 });

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -15,7 +15,6 @@ import hasjQuery from '../helpers/has-jquery';
 import ajax from '../helpers/ajax';
 import Pretender from 'pretender';
 import setupManualTestWaiter from '../helpers/manual-test-waiter';
-import { registerDestructor } from '@ember/destroyable';
 
 module('teardownContext', function (hooks) {
   if (!hasEmberVersion(2, 4)) {
@@ -65,28 +64,16 @@ module('teardownContext', function (hooks) {
     assert.strictEqual(getContext(), undefined, 'context is unset');
   });
 
-  test('destroyables registered with the context are invoked', async function (assert) {
-    registerDestructor(context, () => {
-      assert.step('destructor was ran');
-    });
-
-    assert.step('teardown started');
-
-    await teardownContext(context);
-
-    assert.step('teardown completed');
-
-    assert.verifySteps([
-      'teardown started',
-      'destructor was ran',
-      'teardown completed',
-    ]);
-  });
-
   test('the owner is destroyed', async function (assert) {
     await teardownContext(context);
 
     assert.ok(context.owner.isDestroyed);
+  });
+
+  test('the context is not destroyed', async function (assert) {
+    await teardownContext(context);
+
+    assert.notOk(context.isDestroyed);
   });
 
   test('the application instance is destroyed and unwatched', async function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,11 +1629,6 @@
     "@types/ember__object" "*"
     "@types/ember__owner" "*"
 
-"@types/ember__destroyable@~4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/ember__destroyable/-/ember__destroyable-4.0.1.tgz#6b5d5cd52a6a38ec74ea6b19804a8b4618c8810f"
-  integrity sha512-U497H5zW2bfdwmX1rktaSe+IsOrcqLn7jtrHI2dNnf9le38e1Wcnes8amA9PCv4lOhH+Mc3nkNIdQx38DwflXA==
-
 "@types/ember__engine@*", "@types/ember__engine@~4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/ember__engine/-/ember__engine-4.0.4.tgz#dfa6cda972b1813ab3f012c09e15436c36d1ba2c"
@@ -5759,25 +5754,6 @@ ember-compatibility-helpers@^1.1.2:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
     semver "^5.4.1"
-
-ember-compatibility-helpers@^1.2.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
-  integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==
-  dependencies:
-    babel-plugin-debug-macros "^0.2.0"
-    ember-cli-version-checker "^5.1.1"
-    fs-extra "^9.1.0"
-    semver "^5.4.1"
-
-ember-destroyable-polyfill@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz#1673ed66609a82268ef270a7d917ebd3647f11e1"
-  integrity sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==
-  dependencies:
-    ember-cli-babel "^7.22.1"
-    ember-cli-version-checker "^5.1.1"
-    ember-compatibility-helpers "^1.2.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
In v2.0.0 @ember/test-helpers refactored to use
@ember/destroyable for teardown which also meant
that the application context was destroyed during
teardown, where previously it was only cleaned up
and the application was destroyed.

In our application we have a test helper which
simulates a page refresh by calling
teardownContext and setupContext. The destroyable
change broke this functionality.

This commit effectively reverts the change to use
@ember/destroyable and adds tests to ensure that
the context is not destroyed so that it can be
reset during a test.

https://github.com/emberjs/ember-test-helpers/blob/master/CHANGELOG.md#v200-2020-10-20 https://github.com/emberjs/ember-test-helpers/pull/914/files
https://github.com/emberjs/ember-test-helpers/issues/1452